### PR TITLE
Detect and report error earlier when filepath is valid but no file exists.

### DIFF
--- a/src/main/java/net/visualillusionsent/utils/AbstractPropertiesFile.java
+++ b/src/main/java/net/visualillusionsent/utils/AbstractPropertiesFile.java
@@ -65,6 +65,9 @@ public abstract class AbstractPropertiesFile {
 
         this.filePath = filePath;
         propsFile = new File(filePath);
+        if (!propsFile.exists() || propsFile.isDirectory()) {
+           throw new IllegalArgumentException("File for properties \"" + filePath + "\" is non-existent or a directory.");
+        }
     }
 
     /**


### PR DESCRIPTION
I got a null pointer exception starting CanaryMod locally in this package, and I figured a more informative error message would be useful in the future.
